### PR TITLE
Remove unnecessary files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "functor"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "LICENSE"
   ],
   "main": "./index",
   "browser": "./index.js",


### PR DESCRIPTION
NPM users don't need browserified bundle, tests or Makefiles.

```
package/package.json
package/LICENSE
package/index.js
package/selectn.js
package/Readme.md
package/Makefile
package/component.json
package/examples/stats/package.json
package/examples/stats/index.js
package/examples/stats/stats.json
package/.travis.yml
package/History.md
package/.editorconfig
package/test/index.js
package/test/index.browser.html
(10351 bytes total)
```

This PR shrinks the package by discarding everything except these files:

```
package/package.json
package/index.js
package/Readme.md
(3130 bytes total)
```

The decision of exactly what files should be included is somewhat arbitrary, but I think removing unnecessary parts is worth considering anyway.
